### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Django SHOP Payer Backend
 =========================
 
-[![Build Status](https://travis-ci.org/dessibelle/django-shop-payer-backend.svg?branch=master)](https://travis-ci.org/dessibelle/django-shop-payer-backend) [![Coverage Status](https://coveralls.io/repos/dessibelle/django-shop-payer-backend/badge.svg?branch=master)](https://coveralls.io/r/dessibelle/django-shop-payer-backend?branch=master) [![Latest Version](https://pypip.in/version/django-shop-payer-backend/badge.svg?style=flat)](https://pypi.python.org/pypi/django-shop-payer-backend/)
+[![Build Status](https://travis-ci.org/dessibelle/django-shop-payer-backend.svg?branch=master)](https://travis-ci.org/dessibelle/django-shop-payer-backend) [![Coverage Status](https://coveralls.io/repos/dessibelle/django-shop-payer-backend/badge.svg?branch=master)](https://coveralls.io/r/dessibelle/django-shop-payer-backend?branch=master) [![Latest Version](https://img.shields.io/pypi/v/django-shop-payer-backend.svg?style=flat)](https://pypi.python.org/pypi/django-shop-payer-backend/)
 
 Django SHOP payment backend for [Payer](http://payer.se). Uses [python-payer-api](https://github.com/dessibelle/python-payer-api) for interacting with the API.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-shop-payer-backend))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-shop-payer-backend`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.